### PR TITLE
Added Scala Logging Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ libraryDependencies ++= Seq(
   "io.zman" %% "rummage" % "1.3",
   "com.typesafe.akka" %% "akka-actor" % "2.3.2" % "provided",
   "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0" % "provided",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "org.scalamock" %% "scalamock-scalatest-support" % "3.2" % "test"
 )

--- a/src/main/scala/atmos/dsl/ScalaLoggingSupport.scala
+++ b/src/main/scala/atmos/dsl/ScalaLoggingSupport.scala
@@ -1,0 +1,30 @@
+package atmos.dsl
+
+import atmos.monitor
+import com.typesafe.scalalogging.Logger
+
+/**
+ * Separate namespace for optional Scala Logging support.
+ */
+object ScalaLoggingSupport {
+
+  /**
+   * Creates a new event monitor that submits events to a Scala logger.
+   *
+   * @param logger The Scala logger to supply with event messages.
+   */
+  implicit def scalaLoggerToEventMonitor(logger: Logger): monitor.LogEventsWithSlf4j =
+    monitor.LogEventsWithSlf4j(logger.underlying)
+
+  /**
+   * Creates a new event monitor extension interface for a Scala logger.
+   *
+   * @param logger The logger to create a new event monitor extension interface for.
+   */
+  implicit def scalaLoggerToEventMonitorExtensions(logger: Logger): LogEventsWithSlf4jExtensions =
+    new LogEventsWithSlf4jExtensions(logger)
+
+
+}
+
+

--- a/src/test/scala/atmos/dsl/ScalaLoggingSupportSpec.scala
+++ b/src/test/scala/atmos/dsl/ScalaLoggingSupportSpec.scala
@@ -1,0 +1,50 @@
+/* ScalaLoggingSupportSpec.scala
+ *
+ * Copyright (c) 2013-2014 linkedin.com
+ * Copyright (c) 2013-2014 zman.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package atmos.dsl
+
+import atmos.dsl.ScalaLoggingSupport._
+import atmos.dsl.Slf4jSupport.{Slf4jEventLogLevels, _}
+import atmos.monitor.LogEventsWithSlf4j
+
+import com.typesafe.scalalogging.{Logger => ScalaLogger}
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest._
+import org.slf4j.Logger
+
+/**
+ * Test suite for [[atmos.dsl.Slf4jSupport]].
+ */
+class ScalaLoggingSupportSpec extends FlatSpec with Matchers with MockFactory {
+
+  "ScalaLoggingSupport" should "support viewing Scala-logging-compatible objects as event monitors" in {
+    val logger = mock[Logger]
+    val monitor = ScalaLogger(logger): LogEventsWithSlf4j
+    monitor shouldBe LogEventsWithSlf4j(logger)
+    (monitor: LogEventsWithSlf4jExtensions) shouldBe LogEventsWithSlf4jExtensions(monitor)
+    (logger: LogEventsWithSlf4jExtensions) shouldBe LogEventsWithSlf4jExtensions(LogEventsWithSlf4j(logger))
+  }
+
+  it should "return Slf4j log levels in response to generic level queries" in {
+    Slf4jEventLogLevels.errorLevel shouldBe LogEventsWithSlf4j.Slf4jLevel.Error
+    Slf4jEventLogLevels.warningLevel shouldBe LogEventsWithSlf4j.Slf4jLevel.Warn
+    Slf4jEventLogLevels.infoLevel shouldBe LogEventsWithSlf4j.Slf4jLevel.Info
+    Slf4jEventLogLevels.debugLevel shouldBe LogEventsWithSlf4j.Slf4jLevel.Debug
+  }
+
+}


### PR DESCRIPTION
Currently the event monitor supports slf4j, java and akka loggers. But many scala users are using Scala Logging from TypeSafe.

This pull requests add the implicit conversion from Scala Loggers to Monitor.LogEventsWithSlf4j using the underlying logger given to the scala logger.
